### PR TITLE
WIP: Include instructions for running example on Istio

### DIFF
--- a/Istio-Kubernetes.md
+++ b/Istio-Kubernetes.md
@@ -1,0 +1,66 @@
+# Setup on Istio running on Kubernetes
+
+This example will use [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
+First step is to start this environment:
+
+```
+minikube start
+```
+
+When fully started, then launch the dashboard:
+
+```
+minikube dashboard
+```
+
+NOTE: You may get an error _Could not find finalized endpoint being pointed to by kubernetes-dashboard: Error validating service: Error getting service kubernetes-dashboard: services "kubernetes-dashboard" not found_. If so,
+just wait a while and try again.
+
+NOTE: After using `kubectl create -f ...` to deploy something to Kubernetes, use the console to check that it
+is fully running before moving onto the next step.
+
+## Istio
+
+Follow the instructions for installing [Istio](https://istio.io/docs/setup/kubernetes/quick-start.html) in minikube.
+
+
+## Prometheus (TO BE UPDATED - IGNORE FOR NOW)
+Add configuration to locate services to be monitored based on annotations: prometheus.io/scrape: "true".
+
+```
+kubectl create -f prometheus-kubernetes.yml
+```
+Open the Prometheus dashboard using the link returned from:
+
+```
+minikube service prometheus --url
+```
+
+## OpenTracing
+
+Install an appropriate OpenTracing compliant tracing system.
+
+### Jaeger
+
+Install the Jaeger OpenTracing tracing system:
+
+```
+kubectl apply -n istio-system -f https://raw.githubusercontent.com/jaegertracing/jaeger-kubernetes/master/all-in-one/jaeger-all-in-one-template.yml
+
+```
+
+Once the pods are all started, then open the dashboard using the link returned from:
+
+```
+minikube service jaeger-query --url -n istio-system
+```
+
+## Shutting down
+
+When you have finished running the example, simply run:
+
+```
+minikube stop
+minikube delete
+```
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ First step is to install the OpenTracing compliant tracing system and Prometheus
 
 * [OpenShift instructions](OpenShift.md)
 
+* [Istio/Kubernetes instructions](Istio-Kubernetes.md)
+
 The second step is to try out the example. Instructions are provided in the sub-folder on how to deploy
 and use the example.
 

--- a/simple/Istio-Kubernetes.md
+++ b/simple/Istio-Kubernetes.md
@@ -1,0 +1,32 @@
+# Setup Example using Istio running on Kubernetes
+
+The maven build can be used to automatically build docker images for the two services and deploy them into the
+[local docker register used by minikube](https://kubernetes.io/docs/getting-started-guides/minikube/#reusing-the-docker-daemon).
+
+To use this approach, it is necessary to setup some environment variables before starting the build:
+
+```
+eval $(minikube docker-env)
+
+mvn clean install docker:build
+```
+
+NOTE: To push to a remote registry you can use:
+```
+mvn clean install docker:build docker:push -docker.registry=docker.io/your_username
+```
+
+Run the following command to deploy the services, and prometheus service monitors for those services:
+
+```
+kubectl apply -f <(istioctl kube-inject -f services-istio-kubernetes.yml)
+```
+
+Final step is to obtain the URL for the _ordermgr_ REST endpoint:
+
+```
+export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingress -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
+
+export ORDERMGR=http://$GATEWAY_URL
+```
+

--- a/simple/README.md
+++ b/simple/README.md
@@ -9,6 +9,8 @@ To deploy the example on the appropriate cloud environment:
 
 * [OpenShift instructions](OpenShift.md)
 
+* [Istio/Kubernetes instructions](Istio-Kubernetes.md)
+
 Once the services have been successfully deployed and started it is time to try out the services. Using
 the _ordermgr_ endpoint address (provided as part of the instructions for installing the example in
 the cloud environment), perform some test calls to the service:

--- a/simple/accountmgr/pom.xml
+++ b/simple/accountmgr/pom.xml
@@ -25,7 +25,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 
-		<jaeger.version>0.21.0</jaeger.version>
+		<jaeger.version>0.22.0-RC3</jaeger.version>
 		<prometheus.version>0.0.23</prometheus.version>
 		<prometheus.jmx-exporter.version>0.10</prometheus.jmx-exporter.version>
 		<opentracing-contrib-springweb.version>0.0.12</opentracing-contrib-springweb.version>
@@ -54,6 +54,11 @@
 		<dependency>
 			<groupId>com.uber.jaeger</groupId>
 			<artifactId>jaeger-tracerresolver</artifactId>
+			<version>${jaeger.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.uber.jaeger</groupId>
+			<artifactId>jaeger-b3</artifactId>
 			<version>${jaeger.version}</version>
 		</dependency>
 

--- a/simple/accountmgr/src/main/java/com/example/accountmgr/MetricsConfiguration.java
+++ b/simple/accountmgr/src/main/java/com/example/accountmgr/MetricsConfiguration.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import io.opentracing.contrib.metrics.MetricLabel;
 import io.opentracing.contrib.metrics.label.BaggageMetricLabel;
 import io.opentracing.contrib.metrics.label.ConstMetricLabel;
-
 import org.springframework.context.annotation.Configuration;
 
 @Configuration

--- a/simple/ordermgr/pom.xml
+++ b/simple/ordermgr/pom.xml
@@ -25,7 +25,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 
-		<jaeger.version>0.21.0</jaeger.version>
+		<jaeger.version>0.22.0-RC3</jaeger.version>
 		<prometheus.version>0.0.23</prometheus.version>
 		<prometheus.jmx-exporter.version>0.10</prometheus.jmx-exporter.version>
 		<opentracing-contrib-springweb.version>0.0.12</opentracing-contrib-springweb.version>
@@ -54,6 +54,11 @@
 		<dependency>
 			<groupId>com.uber.jaeger</groupId>
 			<artifactId>jaeger-tracerresolver</artifactId>
+			<version>${jaeger.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.uber.jaeger</groupId>
+			<artifactId>jaeger-b3</artifactId>
 			<version>${jaeger.version}</version>
 		</dependency>
 

--- a/simple/ordermgr/src/main/java/com/example/ordermgr/MetricsConfiguration.java
+++ b/simple/ordermgr/src/main/java/com/example/ordermgr/MetricsConfiguration.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import io.opentracing.contrib.metrics.MetricLabel;
 import io.opentracing.contrib.metrics.label.BaggageMetricLabel;
 import io.opentracing.contrib.metrics.label.ConstMetricLabel;
-
 import org.springframework.context.annotation.Configuration;
 
 @Configuration

--- a/simple/services-istio-kubernetes.yml
+++ b/simple/services-istio-kubernetes.yml
@@ -7,6 +7,7 @@ spec:
   template:
     metadata:
       labels:
+        app: ordermgr
         service: ordermgr
       annotations:
         prometheus.io/scrape: "true"
@@ -23,7 +24,7 @@ spec:
           - name: JAEGER_SERVICE_NAME
             value: ordermgr
           - name: JAEGER_AGENT_HOST
-            value: jaeger-agent
+            value: jaeger-agent.istio-system
           - name: JAEGER_SAMPLER_TYPE
             value: const
           - name: JAEGER_SAMPLER_PARAM
@@ -32,6 +33,8 @@ spec:
             value: "true"
           - name: JAEGER_TAGS
             value: "version=${VERSION}"
+          - name: JAEGER_PROPAGATION
+            value: b3
           - name: ACCOUNTMGR_URL
             value: "http://accountmgr:8080"
           - name: OPENTRACING_METRICS_EXPORTER_HTTP_PATH
@@ -60,6 +63,7 @@ spec:
   template:
     metadata:
       labels:
+        app: accountmgr
         service: accountmgr
       annotations:
         prometheus.io/scrape: "true"
@@ -76,7 +80,7 @@ spec:
           - name: JAEGER_SERVICE_NAME
             value: accountmgr
           - name: JAEGER_AGENT_HOST
-            value: jaeger-agent
+            value: jaeger-agent.istio-system
           - name: JAEGER_SAMPLER_TYPE
             value: const
           - name: JAEGER_SAMPLER_PARAM
@@ -85,6 +89,8 @@ spec:
             value: "true"
           - name: JAEGER_TAGS
             value: "version=${VERSION}"
+          - name: JAEGER_PROPAGATION
+            value: b3
           - name: OPENTRACING_METRICS_EXPORTER_HTTP_PATH
             value: "/metrics"
 ---
@@ -101,4 +107,30 @@ spec:
   ports:
   - name: http
     port: 8080
-
+---
+###########################################################################
+# Ingress resource (gateway)
+##########################################################################
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gateway
+  annotations:
+    kubernetes.io/ingress.class: "istio"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /buy
+        backend:
+          serviceName: ordermgr
+          servicePort: 8080
+      - path: /sell
+        backend:
+          serviceName: ordermgr
+          servicePort: 8080
+      - path: /fail
+        backend:
+          serviceName: ordermgr
+          servicePort: 8080
+---


### PR DESCRIPTION
The following steps are still needed:

- [x] Enable B3 codec to be configured on the Jaeger tracer via environment
- [ ] Investigate why envoy generated operation names have reverted back to host/port, rather than the slightly more useful route name
- [ ] Determine best approach for working with Prometheus - the current template used by Istio uses an older version and does not scrape from applications - so could either update the template/configmap or use the one in this example project?

Current example trace - shows double layer of client/server spans - although the span-kind is not apparent in the overview, but the additional levels may appear too much.

![istio-ordermgr-example](https://user-images.githubusercontent.com/164562/33276747-4efb27c0-d38e-11e7-9e31-b792e6237119.png)

  